### PR TITLE
Updated model projections path to the oficial mexicovid19 repo.

### DIFF
--- a/docs/assets/javascript/grafica_met.js
+++ b/docs/assets/javascript/grafica_met.js
@@ -17,7 +17,7 @@
         },
    w = (w- (margin.left + margin.right) );
     h = (h - (margin.top + margin.bottom));
-var url = "https://raw.githubusercontent.com/blas-ko/Mexico-modelo/master/results/covid19_mex_proyecciones.csv";
+var url = "https://raw.githubusercontent.com/mexicovid19/Mexico-modelo/master/results/covid19_mex_proyecciones.csv";
 
 var tip = d3.select("#grafica_met").append("div")
     .attr("class", "tip")

--- a/docs/assets/javascript/grafica_totales.js
+++ b/docs/assets/javascript/grafica_totales.js
@@ -16,7 +16,7 @@
         },
    w = (w- (margin.left + margin.right) );
     h = (h - (margin.top + margin.bottom));
-var url = "https://raw.githubusercontent.com/blas-ko/Mexico-modelo/master/results/covid19_mex_proyecciones.csv";
+var url = "https://raw.githubusercontent.com/mexicovid19/Mexico-modelo/master/results/covid19_mex_proyecciones.csv";
 
 var tip = d3.select("#grafica_totales").append("div")
     .attr("class", "tip")


### PR DESCRIPTION
from blas-ko/Mexico-modelo to mexicovid19/Mexico-modelo.